### PR TITLE
Close video recorder after recording video

### DIFF
--- a/python/src/causal_rl_bench/viewers/task_viewer.py
+++ b/python/src/causal_rl_bench/viewers/task_viewer.py
@@ -85,6 +85,7 @@ def record_video_of_policy(task, world_params, policy_fn, file_name,
             for _ in range(actual_skip_frame):
                 obs, reward, done, info = env.step(action=desired_action)
                 recorder.capture_frame()
+    recorder.close()
     env.close()
 
 


### PR DESCRIPTION
Without closing the recorder, some videos did not seem to work properly with some viewer apps.