### PR TITLE
performance-only fixes (np.clip, np.array growing, )

### DIFF
--- a/causal_world/envs/robot/action.py
+++ b/causal_world/envs/robot/action.py
@@ -1,7 +1,6 @@
 import numpy as np
-
 from gym import spaces
-
+from causal_world.utils.env_utils import clip
 
 class TriFingerAction(object):
 
@@ -93,9 +92,9 @@ class TriFingerAction(object):
         :return: (nd.array) clipped action.
         """
         if self.normalize_actions:
-            return np.clip(action, -1.0, 1.0)
+            return clip(action, -1.0, 1.0)
         else:
-            return np.clip(action, self.low, self.high)
+            return clip(action, self.low, self.high)
 
     def normalize_action(self, action):
         """

--- a/causal_world/envs/robot/observations.py
+++ b/causal_world/envs/robot/observations.py
@@ -252,7 +252,7 @@ class TriFingerObservations(object):
     def clip_observation(self, observation):
         """
 
-        :param observation: (nd.ardray) observation vector to clip.
+        :param observation: (nd.array) observation vector to clip.
 
         :return: (nd.array) clipped observation vector to satisfy the limits.
         """

--- a/causal_world/envs/robot/observations.py
+++ b/causal_world/envs/robot/observations.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from gym import spaces
-
+from causal_world.utils.env_utils import clip
 
 class TriFingerObservations(object):
 
@@ -252,14 +252,14 @@ class TriFingerObservations(object):
     def clip_observation(self, observation):
         """
 
-        :param observation: (nd.array) observation vector to clip.
+        :param observation: (nd.ardray) observation vector to clip.
 
         :return: (nd.array) clipped observation vector to satisfy the limits.
         """
         if self._normalized_observations:
-            return np.clip(observation, self._low_norm, self._high_norm)
+            return clip(observation, self._low_norm, self._high_norm)
         else:
-            return np.clip(observation, self._low, self._high)
+            return clip(observation, self._low, self._high)
 
     def add_observation(self, observation_key, lower_bound=None,
                         upper_bound=None, observation_fn=None):

--- a/causal_world/envs/robot/trifinger.py
+++ b/causal_world/envs/robot/trifinger.py
@@ -147,7 +147,6 @@ class TriFingerRobot(object):
         current_velocity = np.array(
             [joint[1] for joint in current_joint_states])
         current_torques = np.array([joint[3] for joint in current_joint_states])
-        
         self._latest_full_state = {
             'positions':
                 current_position,

--- a/causal_world/envs/robot/trifinger.py
+++ b/causal_world/envs/robot/trifinger.py
@@ -413,7 +413,7 @@ class TriFingerRobot(object):
                 forces=torque_commands,
                 physicsClientId=self._pybullet_client_full_id)
         return torque_commands
-    
+
     def _safety_torque_check(self, desired_torques):
         """
         limits desired_torques to max_motor_torque 
@@ -423,7 +423,7 @@ class TriFingerRobot(object):
                                             to the robot.
 
         :return: (list) the modified torque commands after applying a safety check.
-        """       
+        """
         applied_torques = clip(
             np.asarray(desired_torques),
             -self._max_motor_torque,
@@ -436,7 +436,7 @@ class TriFingerRobot(object):
                 -self._max_motor_torque,
                 self._max_motor_torque,
         )
-        
+
         return list(applied_torques)
 
     def inverse_kinematics(self, desired_tip_positions, rest_pose):
@@ -638,9 +638,8 @@ class TriFingerRobot(object):
         result[2] -= WorldConstants.FLOOR_HEIGHT
         result[5] -= WorldConstants.FLOOR_HEIGHT
         result[-1] -= WorldConstants.FLOOR_HEIGHT
-        
         return np.array(result)
-    
+
     def _process_action_joint_positions(self, robot_state):
         """
         This returns the absolute joint positions command sent in position control mode

--- a/causal_world/envs/scene/observations.py
+++ b/causal_world/envs/scene/observations.py
@@ -1,5 +1,6 @@
 import numpy as np
 from gym import spaces
+from causal_world.utils.env_utils import clip
 
 
 class StageObservations(object):
@@ -214,7 +215,7 @@ class StageObservations(object):
         """
         lower_key = np.array(self._lower_bounds[key])
         higher_key = np.array(self._upper_bounds[key])
-        if np.array(lower_key == higher_key).all():
+        if (lower_key == higher_key).all():
             return observation
         return (self._high_norm - self._low_norm) * (
             observation - lower_key) / (higher_key - lower_key) + self._low_norm
@@ -228,7 +229,7 @@ class StageObservations(object):
         """
         lower_key = np.array(self._lower_bounds[key])
         higher_key = np.array(self._upper_bounds[key])
-        if np.array(lower_key == higher_key).all():
+        if (lower_key == higher_key).all():
             return observation
         return lower_key + (observation - self._low_norm) / (
             self._high_norm - self._low_norm) * (higher_key - lower_key)
@@ -257,9 +258,9 @@ class StageObservations(object):
         :return: (nd.array) clipped observation vector to satisfy the limits.
         """
         if self._normalized_observations:
-            return np.clip(observation, self._low_norm, self._high_norm)
+            return clip(observation, self._low_norm, self._high_norm)
         else:
-            return np.clip(observation, self._low, self._high)
+            return clip(observation, self._low, self._high)
 
     def get_current_observations(self, helper_keys):
         """

--- a/causal_world/task_generators/base_task.py
+++ b/causal_world/task_generators/base_task.py
@@ -589,19 +589,38 @@ class BaseTask(object):
         for visual_goal in self._stage.get_visual_objects():
             desired_goal.append(self._stage.get_visual_objects()
                                 [visual_goal].get_bounding_box())
+        desired_goal_alternative = np.array(
+            [
+                visual_goal.get_bounding_box()
+                for visual_goal in self._stage.get_visual_objects().values()
+            ]
+        )
+        np.testing.assert_array_equal(desired_goal_alternative , np.array(desired_goal))
         return np.array(desired_goal)
-
+        
     def get_achieved_goal(self):
         """
 
         :return: (nd.array) specifies the achieved goal as bounding boxes of
                             objects by default.
-        """
+        """       
         achieved_goal = []
         for rigid_object in self._stage.get_rigid_objects():
             if self._stage.get_rigid_objects()[rigid_object].is_not_fixed():
                 achieved_goal.append(self._stage.get_rigid_objects()
-                                     [rigid_object].get_bounding_box())
+                                     [rigid_object].get_bounding_box())    
+        
+        achieved_goal = np.array(achieved_goal)
+        
+        achieved_goal2 = np.array(
+            [
+                rigid_object.get_bounding_box() 
+                for rigid_object in self._stage.get_rigid_objects().values()
+                if rigid_object.is_not_fixed()
+            ]
+        )            
+        np.testing.assert_array_equal(np.array(achieved_goal) , achieved_goal2)
+
         return np.array(achieved_goal)
 
     def _goal_reward(self, achieved_goal, desired_goal):

--- a/causal_world/task_generators/base_task.py
+++ b/causal_world/task_generators/base_task.py
@@ -890,17 +890,17 @@ class BaseTask(object):
                         self._robot.\
                             normalize_observation_for_key(
                                 key=key, 
-                                observation=\
-                                self._non_default_robot_observation_funcs[key]()
+                                observation=
+                                    self._non_default_robot_observation_funcs[key]()
                             )
                 else:
                     new_obs = self._non_default_robot_observation_funcs[key]()
             else:
                 new_obs = self._current_full_observations_dict[key]
             
-            if type(new_obs) is np.ndarray:
+            if isinstance(new_obs, np.ndarray):
                 observations_filtered.extend(new_obs.flat)
-            elif type(new_obs) is list or  type(new_obs) is tuple:
+            elif isinstance(new_obs, (list, tuple)):
                 observations_filtered.extend(new_obs)
             else:
                 observations_filtered.append(new_obs)
@@ -918,9 +918,9 @@ class BaseTask(object):
             else:
                 new_obs = self._current_full_observations_dict[key]
             
-            if type(new_obs) is np.ndarray:
+            if isinstance(new_obs, np.ndarray):
                 observations_filtered.extend(new_obs.flat)
-            elif type(new_obs) is list or  type(new_obs) is tuple:
+            elif isinstance(new_obs, (list, tuple)):
                 observations_filtered.extend(new_obs)
             else:
                 observations_filtered.append(new_obs)

--- a/causal_world/task_generators/base_task.py
+++ b/causal_world/task_generators/base_task.py
@@ -924,52 +924,7 @@ class BaseTask(object):
                 observations_filtered.extend(new_obs)
             else:
                 observations_filtered.append(new_obs)
-        # return np.array(observations_filtered)
-        observations_filtered_new = np.array(observations_filtered)
-        
-        observations_filtered = np.array([])
-        for key in self._task_robot_observation_keys:
-            if key in self._non_default_robot_observation_funcs:
-                if self._robot._normalize_observations:
-                    normalized_observations = \
-                        self._robot.\
-                            normalize_observation_for_key\
-                            (key=key, observation=
-                            self._non_default_robot_observation_funcs[key]())
-                    observations_filtered = \
-                        np.append(observations_filtered,
-                                  normalized_observations)
-                else:
-                    observations_filtered =\
-                        np.append(observations_filtered,
-                                  self._non_default_robot_observation_funcs[key]())
-            else:
-                observations_filtered = \
-                    np.append(observations_filtered,
-                              np.array(self._current_full_observations_dict[key]))
-
-        for key in self._task_stage_observation_keys:
-            if key in self._non_default_stage_observation_funcs:
-                if self._stage._normalize_observations:
-                    normalized_observations = \
-                        self._stage.normalize_observation_for_key\
-                            (key=key,
-                             observation=
-                             self._non_default_stage_observation_funcs[key]())
-                    observations_filtered = \
-                        np.append(observations_filtered,
-                                  normalized_observations)
-                else:
-                    observations_filtered =\
-                        np.append(observations_filtered,
-                                  self._non_default_robot_observation_funcs[key]())
-            else:
-                observations_filtered = \
-                    np.append(observations_filtered,
-                              np.array(self._current_full_observations_dict[key]))
-
-        np.testing.assert_equal(observations_filtered_new, observations_filtered)
-        return observations_filtered
+        return np.array(observations_filtered)
 
     def get_task_params(self):
         """

--- a/causal_world/task_generators/base_task.py
+++ b/causal_world/task_generators/base_task.py
@@ -585,18 +585,12 @@ class BaseTask(object):
         :return: (nd.array) specifies the desired goal as bounding boxes of
                             goal shapes by default.
         """
-        desired_goal = []
-        for visual_goal in self._stage.get_visual_objects():
-            desired_goal.append(self._stage.get_visual_objects()
-                                [visual_goal].get_bounding_box())
-        desired_goal_alternative = np.array(
+        return np.array(
             [
                 visual_goal.get_bounding_box()
                 for visual_goal in self._stage.get_visual_objects().values()
             ]
         )
-        np.testing.assert_array_equal(desired_goal_alternative , np.array(desired_goal))
-        return np.array(desired_goal)
         
     def get_achieved_goal(self):
         """
@@ -604,24 +598,13 @@ class BaseTask(object):
         :return: (nd.array) specifies the achieved goal as bounding boxes of
                             objects by default.
         """       
-        achieved_goal = []
-        for rigid_object in self._stage.get_rigid_objects():
-            if self._stage.get_rigid_objects()[rigid_object].is_not_fixed():
-                achieved_goal.append(self._stage.get_rigid_objects()
-                                     [rigid_object].get_bounding_box())    
-        
-        achieved_goal = np.array(achieved_goal)
-        
-        achieved_goal2 = np.array(
+        return np.array(
             [
                 rigid_object.get_bounding_box() 
                 for rigid_object in self._stage.get_rigid_objects().values()
                 if rigid_object.is_not_fixed()
             ]
-        )            
-        np.testing.assert_array_equal(np.array(achieved_goal) , achieved_goal2)
-
-        return np.array(achieved_goal)
+        )   
 
     def _goal_reward(self, achieved_goal, desired_goal):
         """

--- a/causal_world/utils/env_utils.py
+++ b/causal_world/utils/env_utils.py
@@ -1,6 +1,12 @@
 import numpy as np
 from gym import spaces
 
+try:
+    # numpy versions 1.17+ have np.core.umath.clip
+    # as faster alternative to 1.17+ np.clip
+    clip = np.core.umath.clip
+except AttributeError:
+    clip = np.clip
 
 def scale(x, space):
     """

--- a/causal_world/wrappers/env_wrappers.py
+++ b/causal_world/wrappers/env_wrappers.py
@@ -3,7 +3,7 @@ from gym import spaces
 import gym
 
 
-class HERGoalEnvWrapper(gym.GoalEnv):
+class HERGoalEnvWrapper(gym.Env):
 
     def __init__(self, env, activate_sparse_reward=False):
         """

--- a/environment.yml
+++ b/environment.yml
@@ -5,6 +5,7 @@ dependencies:
 - python=3.7.4
 - sphinx
 - jupyter
+- scipy
 - pip:
   - pybullet==2.8.5
   - gym

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,8 @@ setuptools.setup(
         'sphinx_rtd_theme',
         'sphinxcontrib-bibtex',
         'pytest',
-        'psutil'
+        'psutil',
+        'scipy'
       ],
     zip_safe=False
     )


### PR DESCRIPTION
as discussed in #101:
- `np.clip` is slower than `np.core.umath.clip` (saves ~10%) simulation time
- lists instead of np.array growing and smaller fixes (saves ~10% simulation time)

Time before for 10 runs for pusing task (200 steps,3 resets) : `~13.0s +- 200ms `after `10.8s +- 150ms`

All changed functions have been like: 
`np.testing.assert_array_equal(prior_implementation, faster_implementation)` while running the pytests
