### PR TITLE
Updating task generation API in "Getting Started"

### DIFF
--- a/docs/guide/getting_started.rst
+++ b/docs/guide/getting_started.rst
@@ -26,9 +26,9 @@ Setting up an environment can be as simple as two lines of codes
 .. code-block:: python
 
     from causal_world.envs import CausalWorld
-    from causal_world.task_generators import task_generator
+    from causal_world.task_generators.task import generate_task
 
-    task = task_generator(task_generator_id='stacked_blocks')
+    task = generate_task(task_generator_id='stacked_blocks')
     env = CausalWorld(task=task)
     env.reset()
     for _ in range(2000):


### PR DESCRIPTION
Hi, thanks for publishing this environment! I noticed that in the documentation (Getting Started), an older import version of the task generation was used, that does not work anymore with the newest version. This pull request updates this import to work again and be consistent with the remaining examples in the documentation.