### PR TITLE
Fixing GT variable typo

### DIFF
--- a/causal_world/task_generators/base_task.py
+++ b/causal_world/task_generators/base_task.py
@@ -320,7 +320,7 @@ class BaseTask(object):
         info['achieved_goal'] = self._current_achieved_goal
         info['success'] = self._task_solved
         if self._is_ground_truth_state_exposed:
-            info['ground_truth_current_state_varibales'] = \
+            info['ground_truth_current_state_variables'] = \
                 self.get_current_variable_values()
         if self._is_partial_solution_exposed:
             info['possible_solution_intervention'] = dict()

--- a/causal_world/task_generators/reaching.py
+++ b/causal_world/task_generators/reaching.py
@@ -228,7 +228,7 @@ class ReachingTaskGenerator(BaseTask):
         info['achieved_goal'] = self._current_achieved_goal
         info['success'] = self._task_solved
         if self._is_ground_truth_state_exposed:
-            info['ground_truth_current_state_varibales'] = \
+            info['ground_truth_current_state_variables'] = \
                 self.get_current_variable_values()
         if self._is_partial_solution_exposed:
             info['possible_solution_intervention'] = dict()

--- a/docs/guide/task_setups.rst
+++ b/docs/guide/task_setups.rst
@@ -178,7 +178,7 @@ and 0 otherwise.
 
 The info dict - by default - contains the keys fractional_success and success defined as above and the keys
 desired_goal and achieved_goal that might be relevant when training using Hindsight Experience Replay. Additionally
-you can get a nested dictionary of all current state variables via the key ground_truth_current_state_varibales as well
+you can get a nested dictionary of all current state variables via the key ground_truth_current_state_variables as well
 as privileged information in the form of possible solution interventions via the key possible_solution_intervention.
 For this to be added call the methods add_ground_truth_state_to_info() or expose_potential_partial_solution() respectively.
 


### PR DESCRIPTION
Hi, in the info dictionary with the ground truth variables enabled, there has been a typo in the keys (`ground_truth_current_state_varibales` instead of `ground_truth_current_state_variables`). While eventually not crucial, it is probably preferable to correct this typo. This pull request fixes the typo in all places I found.