### PR TITLE
Fix gym and pybullet version

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,8 +7,8 @@ dependencies:
 - jupyter
 - scipy
 - pip:
-  - pybullet==2.8.5
-  - gym
+  - pybullet==3.2.5
+  - gym==0.17.2
   - catkin_pkg
   - sphinx_rtd_theme
   - pytest

--- a/setup.py
+++ b/setup.py
@@ -14,8 +14,8 @@ setuptools.setup(
                                     'assets/robot_properties_fingers/urdf/*.urdf']},
      include_package_data=True,
      install_requires=[
-        'pybullet==2.8.5',
-        'gym',
+        'pybullet==3.2.5',
+        'gym==0.17.2',
         'numpy',
         'catkin_pkg',
         'sphinx',


### PR DESCRIPTION
This PR fixes the versions of gym and pybullet to avoid two issues:

1. An issue with the installation of pybullet on MacOS
2. Some issues with API changes in the latest gym versions